### PR TITLE
fix edge case with lp hashmap optimization

### DIFF
--- a/src/algo/OpenHash.js
+++ b/src/algo/OpenHash.js
@@ -368,13 +368,6 @@ export default class OpenHash extends Hash {
 			this.cmd(act.setHighlight, this.hashTableVisual[candidateIndex], 1);
 			this.cmd(act.step);
 			this.cmd(act.setHighlight, this.hashTableVisual[candidateIndex], 0);
-			
-			if (!this.deleted[candidateIndex]) {
-				nonRemovedEntriesSeen++;
-				if (nonRemovedEntriesSeen === this.size) {
-					break;
-				}
-			}
 
 			if (
 				!this.empty[candidateIndex] &&
@@ -388,6 +381,13 @@ export default class OpenHash extends Hash {
 				(this.deleted[candidateIndex] && this.hashTableValues[candidateIndex].key === key)
 			) {
 				break;
+			}
+
+			if (!this.deleted[candidateIndex]) {
+				nonRemovedEntriesSeen++;
+				if (nonRemovedEntriesSeen === this.size) {
+					break;
+				}
 			}
 
 			if (this.currentProbeType === 'quadratic') {
@@ -631,7 +631,7 @@ export default class OpenHash extends Hash {
 
 		return this.commands;
 	}
-	
+
 	resizeInitialTableCall() {
 		this.clearCallback();
 	}


### PR DESCRIPTION
The current optimization implementation will break before marking the foundIndex, so if it happens to find the key on the size'th probe it will report that the key isn't found. I moved the check to be right after the other stopping conditions, so if it matches it hits that one and properly marks it. It's before the cmd at the end of the loop, so when this break is triggered it won't show the "index to probe" visual which is consistent with the other stopping conditions.