### PR TITLE
add selection sort to 'Sorting and Quicksort' page

### DIFF
--- a/src/AlgoList.js
+++ b/src/AlgoList.js
@@ -251,6 +251,10 @@ export const algoFilter = [
 		category: 'Sorting and Quickselect',
 	},
 	{
+		id: 'SelectionSort',
+		category: 'Sorting and Quickselect',
+	},
+	{
 		id: 'InsertionSort',
 		category: 'Sorting and Quickselect',
 	},


### PR DESCRIPTION
The "Sorting and QuickSelect" page does not currently display a link to SelectionSort:
<img width="1626" alt="Screenshot 2025-03-04 at 8 05 29 PM" src="https://github.com/user-attachments/assets/fcce0f6e-1ede-45bf-91fe-5efb1031df6d" />

This PR adds SelectionSort to that page for students looking to find SelectionSort:
<img width="1695" alt="Screenshot 2025-03-04 at 8 07 00 PM" src="https://github.com/user-attachments/assets/7c4d2094-2bab-4118-848d-2df95d9c9356" />

For reviewers:
`lint` currently throws an error on an unrelated file, and `format` modifies ~30 files unrelated to this change, so I backed out of those.